### PR TITLE
Add option to ignore lock failure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020, Developer Society Limited
+Copyright (c) 2019-2021, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -47,3 +47,9 @@ To exit immediately if a lock can't be acquired:
 .. code-block:: console
 
     $ ./manage.py command_lock --try --name clearsessions -- ./manage.py clearsessions
+
+To ignore a lock failure and return a successful exit code:
+
+.. code-block:: console
+
+    $ ./manage.py command_lock --try --ignore-fail --name clearsessions -- ./manage.py clearsessions

--- a/postgres_lock/management/commands/command_lock.py
+++ b/postgres_lock/management/commands/command_lock.py
@@ -26,6 +26,11 @@ class Command(BaseCommand):
             help="Try and acquire a lock, but fail immediately if the lock cannot be acquired.",
         )
         parser.add_argument(
+            "--ignore-fail",
+            action="store_true",
+            help="Ignore failure if a lock cannot be acquired (return a successful exit code).",
+        )
+        parser.add_argument(
             "--shared",
             action="store_true",
             help="Acquire a lock which can be shared with other sessions.",
@@ -44,5 +49,7 @@ class Command(BaseCommand):
                 # Raise the return code of the child process if an error occurs
                 if completed.returncode != 0:
                     sys.exit(completed.returncode)
+            elif options["ignore_fail"]:
+                self.stderr.write("Unable to acquire lock")
             else:
                 raise CommandError("Unable to acquire lock")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
+from django.test.utils import captured_stderr
 
 
 class TestCommandLockCommand(TestCase):
@@ -25,3 +26,15 @@ class TestCommandLockCommand(TestCase):
 
         with self.assertRaisesMessage(CommandError, "Unable to acquire lock"):
             call_command("command_lock", "--", "true")
+
+    @mock.patch("postgres_lock.lock.PostgresLock.__exit__")
+    @mock.patch("postgres_lock.lock.PostgresLock.__enter__")
+    def test_ignore_fail(self, mock_enter, mock_exit):
+        mock_enter.return_value = False
+        mock_exit.return_value = None
+
+        with captured_stderr() as stderr:
+            result = call_command("command_lock", "--try", "--ignore-fail", "--", "true")
+
+        self.assertIsNone(result)
+        self.assertEqual(stderr.getvalue(), "Unable to acquire lock\n")


### PR DESCRIPTION
Happy Hacktoberfest! 🎃

There's a couple of projects this could be useful, where the command being protected by the lock takes a significant length of time. This ends up returning a failure for exit code, but that isn't something we want to worry about.

This could be done in other ways (`|| exit 0`), however we're using this with uWSGI cron quite a bit.

To test:

On a project which already has this:

```
pip install -e git+https://github.com/developersociety/django-postgres-lock.git@ignore-fail#egg=django-postgres-lock
```

In one tab:

```
./manage.py command_lock -- sleep 300
```

In a second tab:

```
./manage.py command_lock --try --ignore-fail -- sleep 300 && echo "Success"
./manage.py command_lock --try -- sleep 300 && echo "Success"
```

A warning is still given, however it's not considered a failure.