### PR TITLE
CI and version bumps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 branch = true
 parallel = true
 include =
-    postgres_lock/*
+    postgres_lock/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         id: matrix
         run: |
           pip install $(grep "^tox==" requirements/local.txt)
-          echo "::set-output name=tox_matrix::$(tox -l | fgrep -v coverage | python .github/matrix.py)"
+          echo "tox_matrix=$(tox -l | fgrep -v coverage | python .github/matrix.py)" >> $GITHUB_OUTPUT
     outputs:
       tox_matrix: ${{ steps.matrix.outputs.tox_matrix }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   matrix:
     name: Build test matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
 
   test:
     name: Test -- ${{ matrix.tox_env }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: matrix
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on: pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   matrix:
     name: Build test matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Python pip cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-matrix-pip-${{ hashFiles('requirements/testing.txt') }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - name: Run tox
         id: matrix
         run: |
@@ -43,14 +40,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Python pip cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-${{ matrix.tox_env }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements/*.txt'
       - name: Run tests
         env:
           PGHOST: localhost

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2022, Developer Society Limited
+Copyright (c) 2019-2023, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py35']
+target-version = ['py37']
 exclude = '/migrations/'
 
 [tool.isort]

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,6 +2,6 @@
 
 bump2version==1.0.1
 Django>=3.2,<4.0
-psycopg2==2.8.6
-tox==3.25.0
-twine==4.0.0
+psycopg2==2.9.5
+tox==3.28.0
+twine==4.0.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
-black==22.3.0 ; python_version >= '3.6'
+black==22.3.0
 coverage==5.5
 flake8==3.9.2
-isort==5.10.1 ; python_version >= '3.6'
+isort==5.10.1
 pipdeptree==2.2.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
-black==22.3.0
-coverage==5.5
-flake8==3.9.2
-isort==5.10.1
-pipdeptree==2.2.1
+black==23.1.0
+coverage==7.1.0
+flake8==6.0.0 ; python_version >= '3.8'
+isort==5.12.0 ; python_version >= '3.8'
+pipdeptree==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=["Django>=1.11"],
+    install_requires=["Django>=2.2"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
@@ -34,7 +34,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     platforms=["any"],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     install_requires=["Django>=1.11"],
     classifiers=[
         "Intended Audience :: Developers",
@@ -29,8 +29,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     check
     lint
-    {py35,py36,py37}-django1.11
-    {py35,py36,py37,py38,py39}-django2.2
-    {py36,py37,py38,py39,py310}-django3.2
+    py37-django1.11
+    {py37,py38,py39}-django2.2
+    {py37,py38,py39,py310}-django3.2
     coverage
 skipsdist = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     check
     lint
-    py37-django1.11
     {py37,py38,py39}-django2.2
     {py37,py38,py39,py310}-django3.2
     coverage
@@ -11,7 +10,6 @@ skipsdist = true
 [testenv]
 deps =
     -rrequirements/testing.txt
-    django1.11: Django>=1.11,<2.0
     django2.2: Django>=2.2,<3.0
     django3.2: Django>=3.2,<4.0
     psycopg2>=2.8,<2.9


### PR DESCRIPTION
Moving things along a bit, mostly due to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updating CI to 22.04 to give more support in the long run - however that's at the cost of dropped Python 3.5/3.6 - which aren't really supported with various tools anyway.