### PR TITLE
Various minor updates

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 99
-# F405 - ignore wildcard variable warnings, as F403 (don't use wildcard imports) should show the
-# problem anyway. But if we really need wildcard imports - we don't want to noqa every variable.
-# W503 - line break before binary operator, considered not PEP 8 compliant by black.
-ignore = F405,W503

--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -25,7 +25,7 @@ def main():
             }
         )
 
-    print(json.dumps(actions_matrix))
+    print(json.dumps(actions_matrix))  # noqa:T201
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Run tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run tox
         id: matrix
         run: |
-          pip install $(grep "^tox==" requirements/local.txt)
+          pip install $(grep -E "^(tox|tox-uv)==" requirements/local.txt)
           echo "tox_matrix=$(tox -l | fgrep -v coverage | python .github/matrix.py)" >> $GITHUB_OUTPUT
     outputs:
       tox_matrix: ${{ steps.matrix.outputs.tox_matrix }}
@@ -53,7 +53,7 @@ jobs:
           TOX_OVERRIDE: "testenv.passenv=PG*"
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
-          pip install $(grep "^tox==" requirements/local.txt)
+          pip install $(grep -E "^(tox|tox-uv)==" requirements/local.txt)
           tox -e ${{ matrix.tox_env }}
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   matrix:
     name: Build test matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
 
   test:
     name: Test -- ${{ matrix.tox_env }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: matrix
     strategy:
       matrix:
@@ -57,7 +57,7 @@ jobs:
           tox -e ${{ matrix.tox_env }}
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2023, Developer Society Limited
+Copyright (c) 2019-2024, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ test: django-test
 test-report: ## Run and report on unit and integration tests.
 test-report: coverage-clean test coverage-report
 
+test-lowest: ## Run tox with lowest (oldest) package dependencies.
+test-lowest: tox-test-lowest
+
 dist: ## Builds source and wheel package
 dist: clean build-dist
 
@@ -152,6 +155,9 @@ pipdeptree-check:
 # Project testing
 django-test:
 	PYTHONWARNINGS=all coverage run $$(which django-admin) test --pythonpath $$(pwd) --settings tests.settings tests
+
+tox-test-lowest:
+	tox --recreate --override testenv.uv_resolution=lowest
 
 
 # Help

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ check: ## Check for any obvious errors in the project's setup.
 check: pipdeptree-check
 
 format: ## Run this project's code formatters.
-format: black-format isort-format
+format: ruff-format
 
 lint: ## Lint the project.
-lint: black-lint isort-lint flake8-lint
+lint: ruff-lint
 
 test: ## Run unit and integration tests.
 test: django-test
@@ -107,19 +107,6 @@ pip-install-local: venv-check
 	pip install -r requirements/local.txt
 
 
-# ISort
-isort-lint:
-	isort --check-only --diff postgres_lock tests
-
-isort-format:
-	isort postgres_lock tests
-
-
-# Flake8
-flake8-lint:
-	flake8 postgres_lock
-
-
 # Coverage
 coverage-report: coverage-combine coverage-html coverage-xml
 	coverage report --show-missing
@@ -139,17 +126,19 @@ coverage-clean:
 	rm -f .coverage
 
 
-# Black
-black-lint:
-	black --check postgres_lock tests setup.py
+# ruff
+ruff-lint:
+	ruff check
+	ruff format --check
 
-black-format:
-	black postgres_lock tests setup.py
+ruff-format:
+	ruff check --fix-only
+	ruff format
 
 
-#pipdeptree
+# pipdeptree
 pipdeptree-check:
-	@pipdeptree --warn fail > /dev/null
+	pipdeptree --warn fail >/dev/null
 
 
 # Project testing

--- a/postgres_lock/management/commands/command_lock.py
+++ b/postgres_lock/management/commands/command_lock.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             using=options["database"],
         ) as acquired:
             if acquired:
-                completed = subprocess.run(options["command"])
+                completed = subprocess.run(options["command"])  # noqa:S603
                 # Raise the return code of the child process if an error occurs
                 if completed.returncode != 0:
                     sys.exit(completed.returncode)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py37']
+target-version = ['py38']
 exclude = '/migrations/'
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,31 @@
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ['py38']
-exclude = '/migrations/'
+target-version = 'py38'
 
-[tool.isort]
-combine_as_imports = true
-sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']
-known_django = 'django'
-include_trailing_comma = true
-float_to_top = true
-force_grid_wrap = 0
-line_length = 99
-multi_line_output = 3
-skip_glob = '*/migrations/*.py'
+[tool.ruff.lint]
+select = [
+    'F',   # pyflakes
+    'E',   # pycodestyle
+    'W',   # pycodestyle
+    'I',   # isort
+    'N',   # pep8-naming
+    'UP',  # pyupgrade
+    'S',   # flake8-bandit
+    'BLE', # flake8-blind-except
+    'C4',  # flake8-comprehensions
+    'EM',  # flake8-errmsg
+    'T20', # flake8-print
+    'RET', # flake8-return
+    'RUF', # ruff
+]
+ignore = [
+    'EM101', # flake8-errmsg: raw-string-in-exception
+]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = [
+    'assert*',
+]

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,4 +4,5 @@ bump2version==1.0.1
 Django>=4.2,<5.0
 psycopg2==2.9.9
 tox==4.18.1
+tox-uv==1.11.3
 twine==5.1.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 
 bump2version==1.0.1
 Django>=4.2,<5.0
-psycopg2==2.9.9
+psycopg==3.2.1
 tox==4.18.1
 tox-uv==1.11.3
 twine==5.1.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,6 +2,6 @@
 
 bump2version==1.0.1
 Django>=4.2,<5.0
-psycopg2==2.9.6
-tox==4.6.0
-twine==4.0.2
+psycopg2==2.9.9
+tox==4.18.1
+twine==5.1.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
-black==24.3.0 ; python_version >= '3.8'
+black==24.3.0
 coverage==7.2.7
-flake8==6.0.0 ; python_version >= '3.8'
-isort==5.12.0 ; python_version >= '3.8'
+flake8==6.0.0
+isort==5.12.0
 pipdeptree==2.9.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
-black==24.3.0
-coverage==7.2.7
-flake8==6.0.0
-isort==5.12.0
-pipdeptree==2.9.0
+black==24.4.2
+coverage==7.6.1
+flake8==7.1.0
+isort==5.13.2
+pipdeptree==2.23.3

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,3 @@
-black==24.4.2
 coverage==7.6.1
-flake8==7.1.0
-isort==5.13.2
 pipdeptree==2.23.3
+ruff==0.6.5

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     platforms=["any"],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["Django>=2.2"],
     classifiers=[
         "Intended Audience :: Developers",
@@ -29,7 +29,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,6 +9,6 @@ DATABASES = {
 
 USE_TZ = True
 
-SECRET_KEY = "postgres_lock"
+SECRET_KEY = "postgres_lock"  # noqa:S105
 
 INSTALLED_APPS = ["postgres_lock", "tests"]

--- a/tox.ini
+++ b/tox.ini
@@ -18,19 +18,16 @@ deps =
     django3.2,django4.2: psycopg2>=2.9,<2.10
 allowlist_externals = make
 commands = make test
-usedevelop = true
+package = editable
 
 [testenv:check]
 basepython = python3.11
 commands = make check
-skip_install = true
 
 [testenv:lint]
 basepython = python3.11
 commands = make lint
-skip_install = true
 
 [testenv:coverage]
 basepython = python3.11
 commands = make coverage-report
-skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     check
     lint
-    {py37,py38,py39}-django2.2
-    {py37,py38,py39,py310}-django3.2
-    {py38,py39,py310,py311}-django4.2
+    py{38,39}-django2.2
+    py{38,39,310}-django3.2
+    py{38,39,310,311}-django4.2
     coverage
 no_package = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ deps =
     django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<5.0
     django2.2: psycopg2>=2.8,<2.9
-    django3.2,django4.2: psycopg2>=2.9,<2.10
+    django3.2: psycopg2>=2.9,<2.10
+    django4.2: psycopg<3.3
 allowlist_externals = make
 commands = make test
 package = editable

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     lint
     py{38,39}-django2.2
     py{38,39,310}-django3.2
-    py{38,39,310,311}-django4.2
+    py{38,39,310,311,312}-django4.2
     coverage
 no_package = true
 
@@ -21,13 +21,13 @@ commands = make test
 package = editable
 
 [testenv:check]
-basepython = python3.11
+basepython = python3.12
 commands = make check
 
 [testenv:lint]
-basepython = python3.11
+basepython = python3.12
 commands = make lint
 
 [testenv:coverage]
-basepython = python3.11
+basepython = python3.12
 commands = make coverage-report


### PR DESCRIPTION
Nothing too exciting for this PR, it's mostly dropping 3.7 support, adding 3.12 support, switching to ruff, and a bunch of other minor updates.

I've tested this locally with Django 5.1 and it's absolutely fine, but will leave it until Django 5.2 until we add to CI and confirm support.

Wanting to make sure we're keeping some of the packages we use/create up to date a bit more.