### PR TITLE
Python 3.13 and other updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           tox -e ${{ matrix.tox_env }}
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
       - name: Run tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 99
-target-version = 'py38'
+target-version = 'py39'
 
 [tool.ruff.lint]
 select = [

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 
 bump2version==1.0.1
 Django>=4.2,<5.0
-psycopg==3.2.1
-tox==4.18.1
-tox-uv==1.11.3
+psycopg==3.2.3
+tox==4.21.2
+tox-uv==1.13.0
 twine==5.1.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,3 @@
 coverage==7.6.1
-pipdeptree==2.23.3
-ruff==0.6.5
+pipdeptree==2.23.4
+ruff==0.6.9

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     platforms=["any"],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["Django>=2.2"],
     classifiers=[
         "Intended Audience :: Developers",
@@ -29,7 +29,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -22,13 +22,13 @@ commands = make test
 package = editable
 
 [testenv:check]
-basepython = python3.12
+basepython = python3.13
 commands = make check
 
 [testenv:lint]
-basepython = python3.12
+basepython = python3.13
 commands = make lint
 
 [testenv:coverage]
-basepython = python3.12
+basepython = python3.13
 commands = make coverage-report

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     check
     lint
-    py{38,39}-django2.2
-    py{38,39,310}-django3.2
-    py{38,39,310,311,312}-django4.2
+    py39-django2.2
+    py{39,310}-django3.2
+    py{39,310,311,312}-django4.2
     coverage
 no_package = true
 


### PR DESCRIPTION
Just bumping things along, drop official support for 3.8, start some CI with 3.13.

Django 4.2 isn't likely to get 3.13 support - so not testing that in CI. I've tested this locally with Django 5.1 and Python 3.13 - but not going to add that to tox or claim support as we only tend to update this with LTS versions.

Absolutely no reason to do any new release yet(!).