### PR TITLE
Bump version: 0.1.1 → 0.2

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.1.1"
+current_version = "0.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)(\\.(?P<patch>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'django-postgres-lock'
-version = '0.1.1'
+version = '0.2'
 description = 'Django Postgres Lock'
 readme = 'README.md'
 maintainers = [{ name = 'The Developer Society', email = 'studio@dev.ngo' }]


### PR DESCRIPTION
After 3 years - it's time for a new release.

What's changed in the actual code? Not much. We're now using f-strings in a couple of places instead of `.format`, and there's no more `__version__` in `__init__.py`. The rest is mostly CI/testing/packaging tweaks over the years, and confirming support for newer Python/Django.